### PR TITLE
Added .env file and filtering tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.env
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM python:3.6
-ENV PYTHONUNBUFFERED 1
-ENV DJANGO_SETTINGS_MODULE api.config.settings
-ENV SECRET_KEY r#lkao5gtpp@me&4532%!q%sj9yzg)xb-_*mlousmi&=#2r7&w
-ENV DEBUG True
-ENV DATABASE_URL postgres://postgres@db/postgres
-ENV DOCKER_HOST True
+ENV DOCKER_HOST=True
 RUN mkdir /project
 WORKDIR /project
 RUN apt-get update

--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,31 @@ A `RESTful <https://en.wikipedia.org/wiki/Representational_state_transfer>`_ API
 Getting Started
 ---------------
 
-To run this project, you will need to install `Docker <https://docs.docker.com/>`_ on your machine.
 
-Once Docker is installed and running, enter the following command from within the project folder to start the web and database servers:
+
+First create a `.env` file in the root directory that contains necessary environment variables:
+
+.. code::
+
+    # python/django
+    PYTHONUNBUFFERED=1
+    DJANGO_SETTINGS_MODULE=api.config.settings
+    SECRET_KEY=**Django Secret Key**
+    DEBUG=True
+
+    # database
+    DATABASE_URL=postgres://postgres@db/postgres
+
+
+To run this project, you will need to install `Docker <https://docs.docker.com/>`_ on your machine. Once Docker is installed and running and your `.env` file is defined,  enter the following command from within the
+project folder to start the web and database servers:
 
 .. code::
 
   docker-compose up
 
-This will take several minutes the first time you run it as it needs to download and install all the necessary components into a docker container.
+This will take several minutes the first time you run it as it needs to download and install all the necessary
+components into a docker container.
 
 If successful, you should see the following messages at the end of the installation and configuration:
 
@@ -32,4 +48,16 @@ On OS X, you may need to use the IP address of your docker virtual machine rathe
 
     docker-machine ip default
 
-If you installed the Kitematic tool, you should also see your new containers in its list and you can start and stop them from there rather than the command line from now on.
+If you installed the Kitematic tool, you should also see your new containers in its list and you can start and stop them
+from there rather than the command line from now on.
+
+
+Running Tests
+-------------
+
+Make sure you have created a .env file as above. To run all tests:
+
+.. code::
+
+  python manage.py test --settings=api.config.test_settings
+

--- a/api/config/settings.py
+++ b/api/config/settings.py
@@ -6,8 +6,6 @@ SECRET_KEY = os.environ['SECRET_KEY']
 DEBUG = bool(os.environ.get('DEBUG', False))
 DOCKER = bool(os.environ.get('DOCKER_HOST', False))
 
-print(SECRET_KEY)
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/api/config/settings.py
+++ b/api/config/settings.py
@@ -1,11 +1,12 @@
 import os
-import subprocess
 import dj_database_url
 
 # Environment specific settings from environment variables or local .env file
 SECRET_KEY = os.environ['SECRET_KEY']
 DEBUG = bool(os.environ.get('DEBUG', False))
 DOCKER = bool(os.environ.get('DOCKER_HOST', False))
+
+print(SECRET_KEY)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,6 +15,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 ALLOWED_HOSTS = ['*']
+
 
 def show_debug_toolbar(request):
     return DOCKER and DEBUG

--- a/api/config/test_settings.py
+++ b/api/config/test_settings.py
@@ -1,0 +1,18 @@
+"""
+import all default settings and then over write any settings
+that are specific to testing
+
+"""
+import sys
+
+from api.config.settings import *
+
+
+if 'test' in sys.argv or 'test_coverage' in sys.argv:
+    # use an in memory sqlite3 backend for performance
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'default',
+        },
+    }

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -5,7 +5,7 @@ import axelrod as axl
 from api.core.serializers import StrategySerializer, strategy_id
 
 
-def strategies(request):
+def filter_strategies(request):
     """
     Take the incoming request object, convert the strings in its
     query_params dictionary into the types required by the axelrod
@@ -38,7 +38,6 @@ def strategies(request):
 
     if 'makes_use_of' in params:
         filterset['makes_use_of'] = params.getlist('makes_use_of')
-
     return axl.filtered_strategies(filterset)
 
 
@@ -48,7 +47,7 @@ class StrategyViewSet(viewsets.ViewSet):
 
     def list(self, request):
         serializer = StrategySerializer(
-            strategies(request), many=True, context={'request': request})
+            filter_strategies(request), many=True, context={'request': request})
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
   web:
     build: .
+    env_file:
+      - .env
     command: python run_server.py
     volumes:
       - .:/project

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,45 @@
-#!/usr/bin/env python
+"""
+Source:
+https://gist.github.com/bennylope/2999704
+
+Declare all environment files in a .env file and use this manage.py
+to run items that reads this file. This allows us to separate development
+and production environments
+"""
+
+import os
 import sys
+import re
+
+
+def read_env():
+    """Pulled from Honcho code with minor updates, reads local default
+    environment variables from a .env file located in the project root
+    directory.
+    """
+    try:
+        with open('.env') as f:
+            content = f.read()
+    except IOError:
+        content = ''
+
+    for line in content.splitlines():
+        m1 = re.match(r'\A([A-Za-z_0-9]+)=(.*)\Z', line)
+        if m1:
+            key, val = m1.group(1), m1.group(2)
+            m2 = re.match(r"\A'(.*)'\Z", val)
+            if m2:
+                val = m2.group(1)
+            m3 = re.match(r'\A"(.*)"\Z', val)
+            if m3:
+                val = re.sub(r'\\(.)', r'\1', m3.group(1))
+            os.environ.setdefault(key, val)
+
 
 if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+
     from django.core.management import execute_from_command_line
+
+    read_env()
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
This implements a `.env `file for the developer to define environment variables. It adds an extra step to set up & configuration but gives the flexibility to define local development & production builds.

I also refactored the filtering tests and plan to add view/serializer tests in the future (plus travis/CI support).